### PR TITLE
use sha instead of ref to get the correct archive.zip

### DIFF
--- a/htdocs/dist.php
+++ b/htdocs/dist.php
@@ -40,7 +40,7 @@ if ($url) {
     $id = $_GET['id'];
     $ref = $_GET['ref'];
 }
-$url = 'projects/' . $id .'/repository/archive.zip?ref='. $ref;
+$url = 'projects/' . $id .'/repository/archive.zip?sha='. $ref;
 $target = $confs['endpoint'] . $url;
 
 


### PR DESCRIPTION
see also https://gitlab.com/gitlab-org/gitlab-ce/issues/31530

fixes #5 